### PR TITLE
throttle API queries to avoid hitting 1/sec rate-limit

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -12,6 +12,10 @@
 		{
 			"ImportPath": "github.com/stretchr/testify/assert",
 			"Rev": "e897f97d666c44ddbc131f4121c2961034b4c1b4"
+		},
+		{
+			"ImportPath": "github.com/ChimeraCoder/tokenbucket",
+			"Rev": "c5a927568de7aad8a58127d80bcd36ca4e71e454"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/ChimeraCoder/tokenbucket/COPYING
+++ b/Godeps/_workspace/src/github.com/ChimeraCoder/tokenbucket/COPYING
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/Godeps/_workspace/src/github.com/ChimeraCoder/tokenbucket/README
+++ b/Godeps/_workspace/src/github.com/ChimeraCoder/tokenbucket/README
@@ -1,0 +1,48 @@
+[![GoDoc](http://godoc.org/github.com/ChimeraCoder/tokenbucket?status.png)](http://godoc.org/github.com/ChimeraCoder/tokenbucket)
+
+tokenbucket
+====================
+
+This package provides an implementation of [Token bucket](https://en.wikipedia.org/wiki/Token_bucket) scheduling in Go. It is useful for implementing rate-limiting, traffic shaping, or other sorts of scheduling that depend on bandwidth constraints.
+
+
+Example
+------------
+
+
+To create a new bucket, specify a capacity (how many tokens can be stored "in the bank"), and a rate (how often a new token is added).
+
+````go
+
+    // Create a new bucket
+	// Allow a new action every 5 seconds, with a maximum of 3 "in the bank"
+	bucket := tokenbucket.NewBucket(3, 5 * time.Second)
+````
+
+This bucket should be shared between any functions that share the same constraints. (These functions may or may not run in separate goroutines).
+
+
+Anytime a regulated action is performed, spend a token.
+
+````go
+	// To perform a regulated action, we must spend a token
+	// RegulatedAction will not be performed until the bucket contains enough tokens
+	<-bucket.SpendToken(1)
+	RegulatedAction()
+````
+
+`SpendToken` returns immediately. Reading from the channel that it returns will block until the action has "permission" to continue (ie, until there are enough tokens in the bucket).
+
+
+(The channel that `SpendToken` returns is of type `error`. For now, the value will always be `nil`, so it can be ignored.)
+
+
+
+####License
+
+`tokenbucket` is free software provided under version 3 of the LGPL license.
+
+
+Software that uses `tokenbucket` may be released under *any* license, as long as the source code for `tokenbucket` (including any modifications) are made available under the LGPLv3 license.
+
+You do not need to release the rest of the software under the LGPL, or any free/open-source license, for that matter (though we would encourage you to do so!).

--- a/Godeps/_workspace/src/github.com/ChimeraCoder/tokenbucket/tokenbucket.go
+++ b/Godeps/_workspace/src/github.com/ChimeraCoder/tokenbucket/tokenbucket.go
@@ -1,0 +1,86 @@
+package tokenbucket
+
+import (
+	"sync"
+	"time"
+)
+
+type Bucket struct {
+	capacity  int64
+	tokens    chan struct{}
+	rate      time.Duration // Add a token to the bucket every 1/r units of time
+	rateMutex sync.Mutex
+}
+
+func NewBucket(rate time.Duration, capacity int64) *Bucket {
+
+	//A bucket is simply a channel with a buffer representing the maximum size
+	tokens := make(chan struct{}, capacity)
+
+	b := &Bucket{capacity, tokens, rate, sync.Mutex{}}
+
+	//Set off a function that will continuously add tokens to the bucket
+	go func(b *Bucket) {
+		ticker := time.NewTicker(rate)
+		for _ = range ticker.C {
+			b.tokens <- struct{}{}
+		}
+	}(b)
+
+	return b
+}
+
+func (b *Bucket) GetRate() time.Duration {
+	b.rateMutex.Lock()
+	tmp := b.rate
+	b.rateMutex.Unlock()
+	return tmp
+}
+
+func (b *Bucket) SetRate(rate time.Duration) {
+	b.rateMutex.Lock()
+	b.rate = rate
+	b.rateMutex.Unlock()
+}
+
+//AddTokens manually adds n tokens to the bucket
+func (b *Bucket) AddToken(n int64) {
+}
+
+func (b *Bucket) withdrawTokens(n int64) error {
+	for i := int64(0); i < n; i++ {
+		<-b.tokens
+	}
+	return nil
+}
+
+func (b *Bucket) SpendToken(n int64) <-chan error {
+	// Default to spending a single token
+	if n < 0 {
+		n = 1
+	}
+
+	c := make(chan error)
+	go func(b *Bucket, n int64, c chan error) {
+		c <- b.withdrawTokens(n)
+		close(c)
+		return
+	}(b, n, c)
+
+	return c
+}
+
+// Drain will empty all tokens in the bucket
+// If the tokens are being added too quickly (if the rate is too fast)
+// this will never drain
+func (b *Bucket) Drain() error{
+    // TODO replace this with a more solid approach (such as replacing the channel altogether)
+    for {
+        select {
+            case _ = <-b.tokens:
+                continue
+            default:
+                return nil
+        }
+    }
+}

--- a/Godeps/_workspace/src/github.com/ChimeraCoder/tokenbucket/tokenbucket_test.go
+++ b/Godeps/_workspace/src/github.com/ChimeraCoder/tokenbucket/tokenbucket_test.go
@@ -1,0 +1,77 @@
+package tokenbucket_test
+
+import (
+	"github.com/ChimeraCoder/tokenbucket"
+	"testing"
+	"time"
+)
+
+func Example_BucketUse() {
+	// Allow a new action every 5 seconds, with a maximum of 3 "in the bank"
+	bucket := tokenbucket.NewBucket(5*time.Second, 3)
+
+	// To perform a regulated action, we must spend a token
+	// RegulatedAction will not be performed until the bucket contains enough tokens
+	<-bucket.SpendToken(1)
+	RegulatedAction()
+}
+
+// RegulatedAction represents some function that is rate-limited, monitored,
+// or otherwise regulated
+func RegulatedAction() {
+	// Some expensive action goes on here
+}
+
+// Test that a bucket that is full does not block execution
+func Test_BucketBuffering(t *testing.T) {
+	// Create a bucket with capacity 3, that adds tokens every 4 seconds
+	const RATE = 4 * time.Second
+	const CAPACITY = 3
+	const ERROR = 500 * time.Millisecond
+	b := tokenbucket.NewBucket(RATE, CAPACITY)
+
+	// Allow the bucket enough time to fill to capacity
+	time.Sleep(CAPACITY * RATE)
+
+	// Check that we can empty the bucket without wasting any time
+	before := time.Now()
+	<-b.SpendToken(1)
+	<-b.SpendToken(1)
+	<-b.SpendToken(1)
+	after := time.Now()
+
+	if diff := after.Sub(before); diff > RATE {
+		t.Errorf("Waited %d seconds, though this should have been nearly instantaneous", diff)
+	}
+}
+
+// Test that a bucket that is empty blocks execution for the correct amount of time
+func Test_BucketCreation(t *testing.T) {
+	// Create a bucket with capacity 3, that adds tokens every 4 seconds
+	const RATE = 4 * time.Second
+	const CAPACITY = 3
+	const ERROR = 500 * time.Millisecond
+	const EXPECTED_DURATION = RATE * CAPACITY
+
+	b := tokenbucket.NewBucket(RATE, CAPACITY)
+
+	// Ensure that the bucket is empty
+	<-b.SpendToken(1)
+	<-b.SpendToken(1)
+	<-b.SpendToken(1)
+	<-b.SpendToken(1)
+
+	// Spending three times on an empty bucket should take 12 seconds
+	// (Take the average across three, due to imprecision/scheduling)
+	before := time.Now()
+	<-b.SpendToken(1)
+	<-b.SpendToken(1)
+	<-b.SpendToken(1)
+	after := time.Now()
+
+	lower := EXPECTED_DURATION - ERROR
+	upper := EXPECTED_DURATION + ERROR
+	if diff := after.Sub(before); diff < lower || diff > upper {
+		t.Errorf("Waited %s seconds, though really should have waited between %s and %s", diff.String(), lower.String(), upper.String())
+	}
+}


### PR DESCRIPTION
Using the library programmatically resulted in frequent 503 errors because the very low 1/sec rate-limit enforced by Vultr's API was easily hit.
The patch throttles queries to 1/s per client.

Signed-off-by: Jan Broer <janeczku@yahoo.de>