### PR TITLE
API update: Added user-data as option for "server create"

### DIFF
--- a/cmd/commands_servers.go
+++ b/cmd/commands_servers.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 
 	vultr "github.com/JamesClonk/vultr/lib"
@@ -20,6 +21,7 @@ func serversCreate(cmd *cli.Cmd) {
 	ipxe := cmd.StringOpt("ipxe", "", "Chainload the specified URL on bootup, via iPXE, for custom OS")
 	iso := cmd.IntOpt("iso", 0, "ISOID of a specific ISO to mount during the deployment, for custom OS")
 	script := cmd.IntOpt("s script", 0, "SCRIPTID of a startup script to execute on boot (see <scripts>)")
+	userDataFile := cmd.StringOpt("user-data", "", "Path to file with user-data")
 	snapshot := cmd.StringOpt("snapshot", "", "SNAPSHOTID (see <snapshots>) to restore for the initial installation")
 	sshkey := cmd.StringOpt("k sshkey", "", "SSHKEYID (see <sshkeys>) of SSH key to apply to this server on install")
 	ipv6 := cmd.BoolOpt("ipv6", false, "Assign an IPv6 subnet to this virtual machine (where available)")
@@ -36,6 +38,13 @@ func serversCreate(cmd *cli.Cmd) {
 			IPV6:              *ipv6,
 			PrivateNetworking: *privateNetworking,
 			AutoBackups:       *autoBackups,
+		}
+		if *userDataFile != "" {
+			data, err := ioutil.ReadFile(*userDataFile)
+			if err != nil {
+				log.Fatal(err)
+			}
+			options.UserData = string(data)
 		}
 
 		server, err := GetClient().CreateServer(*name, *regionID, *planID, *osID, options)

--- a/lib/servers.go
+++ b/lib/servers.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/url"
 )
@@ -39,6 +40,7 @@ type ServerOptions struct {
 	IPXEChainURL      string
 	ISO               int
 	Script            int
+	UserData          string
 	Snapshot          string
 	SSHKey            string
 	IPV6              bool
@@ -84,6 +86,10 @@ func (c *Client) CreateServer(name string, regionID, planID, osID int, options *
 
 		if options.Script != 0 {
 			values.Add("SCRIPTID", fmt.Sprintf("%v", options.Script))
+		}
+
+		if options.UserData != "" {
+			values.Add("userdata", base64.StdEncoding.EncodeToString([]byte(options.UserData)))
 		}
 
 		if options.Snapshot != "" {

--- a/lib/servers_test.go
+++ b/lib/servers_test.go
@@ -194,6 +194,7 @@ func Test_Servers_CreateServer_OK(t *testing.T) {
 		IPXEChainURL:      "...",
 		ISO:               1,
 		Script:            2,
+		UserData:          "#cloud-config ssh_authorized_keys: - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0g+Z",
 		Snapshot:          "alpha",
 		SSHKey:            "key123",
 		IPV6:              true,


### PR DESCRIPTION
Vultr added a new option to specify user-data during instance deployment.
The API was updated as well. 
See https://www.vultr.com/api/#server_create and https://discuss.vultr.com/discussion/582/cloud-init-user-data-testing
