### PR TITLE
Handle inconsistent API responses for startupscripts

### DIFF
--- a/lib/scripts.go
+++ b/lib/scripts.go
@@ -1,6 +1,10 @@
 package lib
 
-import "net/url"
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
 
 // StartupScript on Vultr account
 type StartupScript struct {
@@ -8,6 +12,26 @@ type StartupScript struct {
 	Name    string `json:"name"`
 	Type    string `json:"type"`
 	Content string `json:"script"`
+}
+
+// Implements json.Unmarshaller on StartupScript.
+// Necessary because the SRIPTID field has inconsistent types.
+func (s *StartupScript) UnmarshalJSON(data []byte) (err error) {
+	if s == nil {
+		*s = StartupScript{}
+	}
+
+	var fields map[string]interface{}
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+
+	s.ID = fmt.Sprintf("%v", fields["SCRIPTID"])
+	s.Name = fmt.Sprintf("%v", fields["name"])
+	s.Type = fmt.Sprintf("%v", fields["type"])
+	s.Content = fmt.Sprintf("%v", fields["script"])
+
+	return
 }
 
 func (c *Client) GetStartupScripts() (scripts []StartupScript, err error) {


### PR DESCRIPTION
Another change to the API happened yesterday making it necessary to deal with inconsistent field types when parsing the API responses in the `StartupScript` struct.

The `/v1/startupscript/create` endpoint now returns `SCRIPTID` as a JSON number.
The `/v1/startupscript/list` endpoint returns the same field as a JSON string.