### PR TITLE
Add support for recent API updates

### DIFF
--- a/cmd/commands_plans.go
+++ b/cmd/commands_plans.go
@@ -20,22 +20,16 @@ func planList(cmd *cli.Cmd) {
 		}
 
 		if *id != 0 {
-			ids, err := GetClient().GetAvailablePlansForRegion(*id)
-			if err != nil {
-				log.Fatal(err)
-			}
-			if len(ids) == 0 {
-				fmt.Println()
-				return
-			}
 			var filteredPlans []vultr.Plan
 			for _, plan := range plans {
-				for _, id := range ids {
-					if id == plan.ID {
+				for _, r := range plan.Regions {
+					if r == *id {
 						filteredPlans = append(filteredPlans, plan)
+						break
 					}
 				}
 			}
+			
 			plans = filteredPlans
 		}
 

--- a/lib/plans.go
+++ b/lib/plans.go
@@ -11,6 +11,7 @@ type Plan struct {
 	Disk      string `json:"disk"`
 	Bandwidth string `json:"bandwidth"`
 	Price     string `json:"price_per_month"`
+	Regions   []int  `json:"available_locations"`
 }
 
 func (c *Client) GetPlans() ([]Plan, error) {

--- a/lib/regions.go
+++ b/lib/regions.go
@@ -7,6 +7,7 @@ type Region struct {
 	Country   string `json:"country"`
 	Continent string `json:"continent"`
 	State     string `json:"state"`
+	Ddos      bool   `json:"ddos_protection"`
 }
 
 func (c *Client) GetRegions() ([]Region, error) {


### PR DESCRIPTION
This PR adds support for new fields that are published via the `plans/list` and `regions/list` API endpoints:

```go
type Region struct {
	(...)
	Ddos  bool   `json:"ddos_protection"`
}

type Plan struct {
	(...)
	Regions   []int  `json:"available_locations"`
}
```

`vultr plans -r ` has been refactored to use a single API call instead of two.