### PR TITLE
Implement retry logic for rate-limit errors

### DIFF
--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/juju/ratelimit"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,6 +19,22 @@ func getTestServerAndClient(code int, body string) (*httptest.Server, *Client) {
 
 func getTestServer(code int, body string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+}
+
+func getTestServerThrottled(body string) *httptest.Server {
+	var rateLimiter *ratelimit.Bucket
+	// Rate limit: 2 req/s, capacity 2
+	rateLimiter = ratelimit.NewBucket(500*time.Millisecond, 2)
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		code := 200
+		if tokens := rateLimiter.TakeAvailable(1); tokens == 0 {
+			code = 503
+		}
+
 		w.WriteHeader(code)
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, body)
@@ -87,4 +105,30 @@ func Test_Client_Throttling(t *testing.T) {
 	if diff := after.Sub(before); diff < lower || diff > upper {
 		t.Errorf("Waited %s seconds, though really should have waited between %s and %s", diff.String(), lower.String(), upper.String())
 	}
+}
+
+// Test that retry logic is working
+func Test_Client_Retry(t *testing.T) {
+	server := getTestServerThrottled(`{
+		"balance":-15.97,"pending_charges":"2.34",
+		"last_payment_date":"2015-01-29 05:06:27","last_payment_amount":"-5.00"}`)
+	defer server.Close()
+
+	options := Options{
+		Endpoint:   server.URL,
+		MaxRetries: 5,
+	}
+	client := NewClient("test-key", &options)
+
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := client.GetAccountInfo()
+			assert.NoError(t, err)
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
Our client already throttles API requests according to Vultr’s 2 req/s
rate-limit. But when there are multiple clients making concurrent
requests (e.g. Docker Machine with multiple Vultr instances)  many
operations still fail due to rate-limit-exceeded errors returned from
the API. This patch implements automatic retry logic to deal with these
errors. Retries are delayed using an ever increasing backoff duration
with a randomized jitter of 0-30% that should minimize successive
collisions. The maximum number of retries is configurable with the
MaxRetries options and defaults to zero retries.