### PR TITLE
Add support for ISO management

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -48,6 +48,11 @@ func (c *CLI) RegisterCommands() {
 			cmd.Command("change", "change operating system of virtual machine (all data will be lost)", serversChangeOS)
 			cmd.Command("list", "show a list of operating systems to which can be changed to", serversListOS)
 		})
+		cmd.Command("iso", "attach/detach ISO of a virtual machine", func(cmd *cli.Cmd) {
+			cmd.Command("attach", "attach ISO to a virtual machine (server will hard reboot)", serversAttachISO)
+			cmd.Command("detach", "detach ISO from a virtual machine (server will hard reboot)", serversDetachISO)
+			cmd.Command("status", "show status of ISO attached to a virtual machine", serversStatusISO)
+		})
 		cmd.Command("delete", "delete a virtual machine", serversDelete)
 		cmd.Command("bandwidth", "list bandwidth used by a virtual machine", serversBandwidth)
 		cmd.Command("list", "list all active or pending virtual machines on current account", serversList)

--- a/cmd/commands_servers.go
+++ b/cmd/commands_servers.go
@@ -126,6 +126,50 @@ func serversChangeOS(cmd *cli.Cmd) {
 	}
 }
 
+func serversAttachISO(cmd *cli.Cmd) {
+	cmd.Spec = "SUBID -i"
+	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
+	isoID := cmd.IntOpt("i iso", 0, "ISO ID (ISOID)")
+	cmd.Action = func() {
+		if err := GetClient().AttachISOtoServer(*id, *isoID); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Virtual machine ISO attached, server will reboot: %v\n", *isoID)
+	}
+}
+
+func serversDetachISO(cmd *cli.Cmd) {
+	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
+	cmd.Action = func() {
+		if err := GetClient().DetachISOfromServer(*id); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Virtual machine ISO detached, server will reboot\n")
+	}
+}
+
+func serversStatusISO(cmd *cli.Cmd) {
+	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
+	cmd.Action = func() {
+		iso, err := GetClient().GetISOStatusofServer(*id)
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if iso.State == "" {
+			fmt.Printf("Couldn't determine ISO state of virtual machine on SUBID %v!\n", *id)
+			return
+		}
+
+		lengths := []int{24, 64}
+		tabsPrint(Columns{"Id (SUBID):", *id}, lengths)
+		tabsPrint(Columns{"State:", iso.State}, lengths)
+		tabsPrint(Columns{"Iso (ISOID):", iso.ISOID}, lengths)
+		tabsFlush()
+	}
+}
+
 func serversListOS(cmd *cli.Cmd) {
 	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
 	cmd.Action = func() {

--- a/lib/servers.go
+++ b/lib/servers.go
@@ -59,6 +59,11 @@ type V6Network struct {
 	NetworkSize string `json:"v6_network_size"`
 }
 
+type ISOStatus struct {
+	State       string `json:"state"`
+	ISOID       string `json:"ISOID"`
+}
+
 // UnmarshalJSON implements json.Unmarshaller on Server.
 // This is needed because the Vultr API is inconsistent in it's JSON responses for servers.
 // Some fields can change type, from JSON number to JSON string and vice-versa.
@@ -333,6 +338,37 @@ func (c *Client) ChangeOSofServer(id string, osID int) error {
 		return err
 	}
 	return nil
+}
+
+func (c *Client) AttachISOtoServer(id string, isoID int) error {
+	values := url.Values{
+		"SUBID": {id},
+		"ISOID":  {fmt.Sprintf("%v", isoID)},
+	}
+
+	if err := c.post(`server/iso_attach`, values, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) DetachISOfromServer(id string) error {
+	values := url.Values{
+		"SUBID": {id},
+	}
+
+	if err := c.post(`server/iso_detach`, values, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) GetISOStatusofServer(id string)(isoStatus ISOStatus, err error) {
+	if err := c.get(`server/iso_status?SUBID=`+id, &isoStatus); err != nil {
+		return ISOStatus{}, err
+	}
+
+	return isoStatus, nil
 }
 
 func (c *Client) ListOSforServer(id string) (os []OS, err error) {


### PR DESCRIPTION
This change allows ISO's to be managed on a given virtual machine.

```
$ vultr server iso attach 1234567 -i 756453
Virtual machine ISO attached, server will reboot: 1234567

$ vultr server iso status 1234567
Id (SUBID):	1234567
State:		isomounted
Iso (ISOID):	756453

$ vultr server iso detach 1234567
Virtual machine ISO detached, server will reboot: 1234567
```