### PR TITLE
Disable HTTP2 upgrade to avoid REFUSED_STREAM failure when doing POST

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -75,7 +76,11 @@ type Options struct {
 // NewClient creates new Vultr API client. Options are optional and can be nil.
 func NewClient(apiKey string, options *Options) *Client {
 	userAgent := "vultr-go/" + Version
+	transport := &http.Transport{
+		TLSNextProto: make(map[string]func(string, *tls.Conn) http.RoundTripper),
+	}
 	client := http.DefaultClient
+	client.Transport = transport
 	endpoint, _ := url.Parse(DefaultEndpoint)
 	rate := 505 * time.Millisecond
 	attempts := 1


### PR DESCRIPTION
On Go 1.7rc6 the http.Client tries to upgrade the transport to HTTP2 when doing POST request, for example doing `vultr server create`. 

The generate a HTTP2 stream error:
`2016/08/13 13:44:32 Post https://api.vultr.com/v1/server/create?api_key=myKey: stream error: stream ID 1; REFUSED_STREAM`

This pull request force disables HTTP2 upgrade by setting Transport.TLSNextProto to an empty map according to the Overview section of: https://golang.org/pkg/net/http/

Tested with Go 1.7rc6 on macOS Sierra 10.12 Beta (16A286a)