### PR TITLE
cmd,lib: add ability to tag instances

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -73,6 +73,7 @@ func (c *CLI) RegisterCommands() {
 	c.Command("server", "modify virtual machines", func(cmd *cli.Cmd) {
 		cmd.Command("create", "create a new virtual machine", serversCreate)
 		cmd.Command("rename", "rename a virtual machine", serversRename)
+		cmd.Command("tag", "tag a virtual machine", serversTag)
 		cmd.Command("start", "start a virtual machine (restart if already running)", serversStart)
 		cmd.Command("halt", "halt a virtual machine (hard power off)", serversHalt)
 		cmd.Command("reboot", "reboot a virtual machine (hard reboot)", serversReboot)

--- a/cmd/commands_servers.go
+++ b/cmd/commands_servers.go
@@ -85,6 +85,19 @@ func serversRename(cmd *cli.Cmd) {
 	}
 }
 
+func serversTag(cmd *cli.Cmd) {
+	cmd.Spec = "SUBID -t"
+	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
+	tag := cmd.StringOpt("t tag", "", "new tag for virtual machine")
+
+	cmd.Action = func() {
+		if err := GetClient().TagServer(*id, *tag); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Virtual machine tagged with: %v\n", *tag)
+	}
+}
+
 func serversStart(cmd *cli.Cmd) {
 	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
 	cmd.Action = func() {

--- a/lib/servers.go
+++ b/lib/servers.go
@@ -354,6 +354,19 @@ func (c *Client) RenameServer(id, name string) error {
 	return nil
 }
 
+// TagServer replaces the tag on an existing virtual machine
+func (c *Client) TagServer(id, tag string) error {
+	values := url.Values{
+		"SUBID": {id},
+		"tag":   {tag},
+	}
+
+	if err := c.post(`server/tag_set`, values, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
 // StartServer starts an existing virtual machine
 func (c *Client) StartServer(id string) error {
 	values := url.Values{

--- a/lib/servers_test.go
+++ b/lib/servers_test.go
@@ -296,6 +296,23 @@ func Test_Servers_RenameServer_OK(t *testing.T) {
 	assert.Nil(t, client.RenameServer("123456789", "new-name"))
 }
 
+func Test_Servers_TagServer_Error(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
+	defer server.Close()
+
+	err := client.TagServer("123456789", "new-tag")
+	if assert.NotNil(t, err) {
+		assert.Equal(t, `{error}`, err.Error())
+	}
+}
+
+func Test_Servers_TagServer_OK(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusOK, `{no-response?!}`)
+	defer server.Close()
+
+	assert.Nil(t, client.TagServer("123456789", "new-tag"))
+}
+
 func Test_Servers_StartServer_Error(t *testing.T) {
 	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
 	defer server.Close()


### PR DESCRIPTION
This commit enables the https://www.vultr.com/api/#server_tag_set" API
so that the client can now tag and retag virtual machines.