### PR TITLE
cmd,lib: create and delete IPv4 addresses

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -96,6 +96,8 @@ func (c *CLI) RegisterCommands() {
 		cmd.Command("show", "show detailed information of a virtual machine", serversShow)
 		// ip information
 		cmd.Command("list-ipv4", "list IPv4 information of a virtual machine", ipv4List)
+		cmd.Command("create-ipv4", "add a new IPv4 address to a virtual machine", ipv4Create)
+		cmd.Command("delete-ipv4", "remove IPv4 address from a virtual machine", ipv4Delete)
 		cmd.Command("list-ipv6", "list IPv6 information of a virtual machine", ipv6List)
 		// reverse dns
 		cmd.Command("reverse-dns", "modify reverse DNS entries", func(cmd *cli.Cmd) {

--- a/cmd/commands_servers.go
+++ b/cmd/commands_servers.go
@@ -382,6 +382,32 @@ func ipv4List(cmd *cli.Cmd) {
 	}
 }
 
+func ipv4Create(cmd *cli.Cmd) {
+	cmd.Spec = "SUBID"
+	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
+	reboot := cmd.BoolOpt("r reboot", false, "reboot virtual machine after attaching IPv4 address")
+
+	cmd.Action = func() {
+		if err := GetClient().CreateIPv4(*id, *reboot); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("IPv4 address attached to virtual machine")
+	}
+}
+
+func ipv4Delete(cmd *cli.Cmd) {
+	cmd.Spec = "SUBID IP"
+	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
+	ip := cmd.StringArg("IP", "", "IPv4 of virtual machine (see <list-ipv4>)")
+
+	cmd.Action = func() {
+		if err := GetClient().DeleteIPv4(*id, *ip); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("IPv4 address deleted")
+	}
+}
+
 func ipv6List(cmd *cli.Cmd) {
 	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
 	cmd.Action = func() {

--- a/lib/ip.go
+++ b/lib/ip.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"fmt"
 	"net/url"
 	"sort"
 )
@@ -76,6 +77,32 @@ func (c *Client) ListIPv4(id string) (list []IPv4, err error) {
 	}
 	sort.Sort(ipv4s(list))
 	return list, nil
+}
+
+// CreateIPv4 creates an IPv4 address and attaches it to a virtual machine
+func (c *Client) CreateIPv4(id string, reboot bool) error {
+	values := url.Values{
+		"SUBID":  {id},
+		"reboot": {fmt.Sprintf("%t", reboot)},
+	}
+
+	if err := c.post(`server/create_ipv4`, values, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteIPv4 deletes an IPv4 address and detaches it from a virtual machine
+func (c *Client) DeleteIPv4(id, ip string) error {
+	values := url.Values{
+		"SUBID": {id},
+		"ip":    {ip},
+	}
+
+	if err := c.post(`server/destroy_ipv4`, values, nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ListIPv6 lists the IPv4 information of a virtual machine

--- a/lib/ip_test.go
+++ b/lib/ip_test.go
@@ -61,6 +61,40 @@ func Test_IP_ListIPv4_OK(t *testing.T) {
 	}
 }
 
+func Test_IP_CreateIPv4_Error(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
+	defer server.Close()
+
+	err := client.CreateIPv4("123456789", true)
+	if assert.NotNil(t, err) {
+		assert.Equal(t, `{error}`, err.Error())
+	}
+}
+
+func Test_IP_CreateIPv4_OK(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusOK, `{no-response?!}`)
+	defer server.Close()
+
+	assert.Nil(t, client.CreateIPv4("123456789", true))
+}
+
+func Test_IP_DeleteIPv4_Error(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
+	defer server.Close()
+
+	err := client.DeleteIPv4("123456789", "123.123.123.123")
+	if assert.NotNil(t, err) {
+		assert.Equal(t, `{error}`, err.Error())
+	}
+}
+
+func Test_IP_DeleteIPv4_OK(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusOK, `{no-response?!}`)
+	defer server.Close()
+
+	assert.Nil(t, client.DeleteIPv4("123456789", "123.123.123.123"))
+}
+
 func Test_IP_ListIPv6_Error(t *testing.T) {
 	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
 	defer server.Close()


### PR DESCRIPTION
This commit adds functionality to allow adding and removing IPv4
addresses from virtual machines. It adds two new subcommands to the
`server` command: `create-ipv4` and `delete-ipv4`.