### PR TITLE
cmd,lib: enable firewall_group_set endpoint

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -106,6 +106,9 @@ func (c *CLI) RegisterCommands() {
 			cmd.Command("delete-ipv6", "delete IPv6 reverse DNS entry", reverseIpv6Delete)
 			cmd.Command("list-ipv6", "list IPv6 reverse DNS entries of a virtual machine", reverseIpv6List)
 		})
+		// firewall groups
+		cmd.Command("set-firewall-group", "set firewall group of a virtual machine", serversSetFirewallGroup)
+		cmd.Command("unset-firewall-group", "remove virtual machine from firewall group", serversUnsetFirewallGroup)
 	})
 	c.Command("servers", "list all active or pending virtual machines on current account", serversList)
 

--- a/cmd/commands_servers.go
+++ b/cmd/commands_servers.go
@@ -98,6 +98,31 @@ func serversTag(cmd *cli.Cmd) {
 	}
 }
 
+func serversSetFirewallGroup(cmd *cli.Cmd) {
+	cmd.Spec = "SUBID GROUP_ID"
+	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
+	gid := cmd.StringArg("GROUP_ID", "", "Firewall group ID (see <firewall group list>)")
+
+	cmd.Action = func() {
+		if err := GetClient().SetFirewallGroup(*id, *gid); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Virtual machine added to firewall group: %v\n", *gid)
+	}
+}
+
+func serversUnsetFirewallGroup(cmd *cli.Cmd) {
+	cmd.Spec = "SUBID"
+	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
+
+	cmd.Action = func() {
+		if err := GetClient().UnsetFirewallGroup(*id); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println("Virtual machine removed from firewall group")
+	}
+}
+
 func serversStart(cmd *cli.Cmd) {
 	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
 	cmd.Action = func() {

--- a/lib/servers.go
+++ b/lib/servers.go
@@ -487,6 +487,24 @@ func (c *Client) DeleteServer(id string) error {
 	return nil
 }
 
+// SetFirewallGroup adds a virtual machine to a firewall group
+func (c *Client) SetFirewallGroup(id, firewallgroup string) error {
+	values := url.Values{
+		"SUBID":           {id},
+		"FIREWALLGROUPID": {firewallgroup},
+	}
+
+	if err := c.post(`server/firewall_group_set`, values, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+// UnsetFirewallGroup removes a virtual machine from a firewall group
+func (c *Client) UnsetFirewallGroup(id string) error {
+	return c.SetFirewallGroup(id, "0")
+}
+
 // BandwidthOfServer retrieves the bandwidth used by a virtual machine
 func (c *Client) BandwidthOfServer(id string) (bandwidth []map[string]string, err error) {
 	var bandwidthMap map[string][][]string

--- a/lib/servers_test.go
+++ b/lib/servers_test.go
@@ -398,6 +398,40 @@ func Test_Servers_DeleteServer_OK(t *testing.T) {
 	assert.Nil(t, client.DeleteServer("123456789"))
 }
 
+func Test_Servers_SetFirewallGroup_Error(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
+	defer server.Close()
+
+	err := client.SetFirewallGroup("123456789", "123456789")
+	if assert.NotNil(t, err) {
+		assert.Equal(t, `{error}`, err.Error())
+	}
+}
+
+func Test_Servers_SetFirewallGroup_OK(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusOK, `{no-response?!}`)
+	defer server.Close()
+
+	assert.Nil(t, client.SetFirewallGroup("123456789", "123456789"))
+}
+
+func Test_Servers_UnsetFirewallGroup_Error(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
+	defer server.Close()
+
+	err := client.UnsetFirewallGroup("123456789")
+	if assert.NotNil(t, err) {
+		assert.Equal(t, `{error}`, err.Error())
+	}
+}
+
+func Test_Servers_UnsetFirewallGroup_OK(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusOK, `{no-response?!}`)
+	defer server.Close()
+
+	assert.Nil(t, client.UnsetFirewallGroup("123456789"))
+}
+
 func Test_Servers_ChangeOSofServer_Error(t *testing.T) {
 	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
 	defer server.Close()


### PR DESCRIPTION
This commit adds to new functions to the API: `SetFirewallGroup` and
`UnsetFireWallGroup` to allow adding and removing a virtual machine from
a firewall group. These functions use the
`/v1/server/firewall_group_set` endpoint.