### PR TITLE
cmd,lib: enable set firewall group description

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -30,6 +30,7 @@ func (c *CLI) RegisterCommands() {
 		cmd.Command("group", "show and change firewall groups", func(cmd *cli.Cmd) {
 			cmd.Command("create", "create a firewall group", firewallGroupCreate)
 			cmd.Command("delete", "delete a firewall group", firewallGroupDelete)
+			cmd.Command("set-description", "set firewall group description", firewallGroupSetDescription)
 			cmd.Command("list", "list all firewall groups", firewallGroupList)
 		})
 		cmd.Command("rule", "show and change firewall rules", func(cmd *cli.Cmd) {

--- a/cmd/commands_firewall.go
+++ b/cmd/commands_firewall.go
@@ -41,6 +41,21 @@ func firewallGroupDelete(cmd *cli.Cmd) {
 	}
 }
 
+func firewallGroupSetDescription(cmd *cli.Cmd) {
+	cmd.Spec = "GROUP_ID DESCRIPTION"
+
+	gid := cmd.StringArg("GROUP_ID", "", "Firewall group ID")
+	desc := cmd.StringArg("DESCRIPTION", "", "New description for the firewall group")
+
+	cmd.Action = func() {
+		if err := GetClient().SetFirewallGroupDescription(*gid, *desc); err != nil {
+			log.Fatal(err)
+		}
+
+		fmt.Printf("Set description for firewall group %s: %s\n", *gid, *desc)
+	}
+}
+
 func firewallGroupList(cmd *cli.Cmd) {
 	cmd.Action = func() {
 		groups, err := GetClient().GetFirewallGroups()

--- a/lib/firewall.go
+++ b/lib/firewall.go
@@ -156,6 +156,19 @@ func (c *Client) DeleteFirewallGroup(groupID string) error {
 	return nil
 }
 
+// SetFirewallGroupDescription sets the description of an existing firewall group
+func (c *Client) SetFirewallGroupDescription(groupID, description string) error {
+	values := url.Values{
+		"FIREWALLGROUPID": {groupID},
+		"description":     {description},
+	}
+
+	if err := c.post(`firewall/group_set_description`, values, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetFirewallRules returns a list of rules for the given firewall group
 func (c *Client) GetFirewallRules(groupID string) ([]FirewallRule, error) {
 	var ruleMap map[string]FirewallRule

--- a/lib/firewall_test.go
+++ b/lib/firewall_test.go
@@ -89,6 +89,23 @@ func Test_Firewall_DeleteGroup_Ok(t *testing.T) {
 	}
 }
 
+func Test_Firewall_SetGroupDescription_Error(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
+	defer server.Close()
+
+	err := client.SetFirewallGroupDescription("123456789", "new description")
+	if assert.NotNil(t, err) {
+		assert.Equal(t, `{error}`, err.Error())
+	}
+}
+
+func Test_Firewall_SetGroupDescription_OK(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusOK, `{no-response?!}`)
+	defer server.Close()
+
+	assert.Nil(t, client.SetFirewallGroupDescription("123456789", "new description"))
+}
+
 func Test_Firewall_GetRules_Fail(t *testing.T) {
 	server, client := getTestServerAndClient(http.StatusNotAcceptable, ``)
 	defer server.Close()


### PR DESCRIPTION
This commit enables the `/v1/firewall/group_set_description` API
endpoint and adds a new command: `firewall group set-description`.