### PR TITLE
lib: fix unmarshalling ipv6 ::/0

### DIFF
--- a/lib/firewall.go
+++ b/lib/firewall.go
@@ -84,13 +84,17 @@ func (r *FirewallRule) UnmarshalJSON(data []byte) (err error) {
 	r.Protocol = fmt.Sprintf("%v", fields["protocol"])
 	r.Port = fmt.Sprintf("%v", fields["port"])
 	subnet := fmt.Sprintf("%v", fields["subnet"])
+	if subnet == "<nil>" {
+		subnet = ""
+	}
 
-	if subnetSize > 0 && len(subnet) > 0 {
+	if len(subnet) > 0 {
 		_, r.Network, err = net.ParseCIDR(fmt.Sprintf("%s/%d", subnet, subnetSize))
 		if err != nil {
 			return fmt.Errorf("Failed to parse subnet from Vultr API")
 		}
 	} else {
+		// This case is used to create a valid default CIDR when the Vultr API does not return a subnet/subnet size at all, e.g. the response after creating a new rule.
 		_, r.Network, _ = net.ParseCIDR("0.0.0.0/0")
 	}
 

--- a/lib/firewall_test.go
+++ b/lib/firewall_test.go
@@ -136,6 +136,10 @@ func Test_Firewall_GetRules_Ok(t *testing.T) {
     "2":{
         "rulenumber":2,"action":"accept","protocol": "tcp","port": "80",
         "subnet": "10.234.22.0","subnet_size": 24
+    },
+    "3":{
+        "rulenumber":3,"action":"accept","protocol": "tcp","port": "80",
+	"subnet": "::","subnet_size": 0
     }}`)
 	defer server.Close()
 
@@ -144,7 +148,7 @@ func Test_Firewall_GetRules_Ok(t *testing.T) {
 		t.Error(err)
 	}
 	if assert.NotNil(t, rules) {
-		assert.Equal(t, 2, len(rules))
+		assert.Equal(t, 3, len(rules))
 
 		assert.Equal(t, rules[0].RuleNumber, 1)
 		assert.Equal(t, rules[0].Action, "accept")
@@ -159,6 +163,13 @@ func Test_Firewall_GetRules_Ok(t *testing.T) {
 		assert.Equal(t, rules[1].Port, "80")
 		_, netw, _ = net.ParseCIDR("10.234.22.0/24")
 		assert.Equal(t, rules[1].Network, netw)
+
+		assert.Equal(t, rules[2].RuleNumber, 3)
+		assert.Equal(t, rules[2].Action, "accept")
+		assert.Equal(t, rules[2].Protocol, "tcp")
+		assert.Equal(t, rules[2].Port, "80")
+		_, netw, _ = net.ParseCIDR("::/0")
+		assert.Equal(t, rules[2].Network, netw)
 	}
 }
 


### PR DESCRIPTION
If you log into Vultr console and create an IPv6 firewall rule for `::/0` then in the CLI you do:
```
vultr firewall rule list <firewall group ID>
```
you incorrectly get a IPv4 CIDR like so:
```
RULE_NUM        ACTION  PROTOCOL        PORT    NETWORK
1               accept  tcp             80    0.0.0.0/0
```

This PR fixes this issue and adds a test to validate.