### PR TITLE
Build vultr cli on current stable Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.7
   - 1.8
+  - 1.9
   - tip
 env:
   - GOARCH=amd64


### PR DESCRIPTION
This updates the Travis build to use current Go version 1.8 and 1.9, dropping the archived version 1.7.