### PR TITLE
Moved API key to request header

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -120,13 +120,6 @@ func apiPath(path string) string {
 	return fmt.Sprintf("/%s/%s", APIVersion, path)
 }
 
-func apiKeyPath(path, apiKey string) string {
-	if strings.Contains(path, "?") {
-		return path + "&api_key=" + apiKey
-	}
-	return path + "?api_key=" + apiKey
-}
-
 func (c *Client) get(path string, data interface{}) error {
 	req, err := c.newRequest("GET", apiPath(path), nil)
 	if err != nil {
@@ -144,7 +137,7 @@ func (c *Client) post(path string, values url.Values, data interface{}) error {
 }
 
 func (c *Client) newRequest(method string, path string, body io.Reader) (*http.Request, error) {
-	relPath, err := url.Parse(apiKeyPath(path, c.APIKey))
+	relPath, err := url.Parse(path)
 	if err != nil {
 		return nil, err
 	}
@@ -156,6 +149,7 @@ func (c *Client) newRequest(method string, path string, body io.Reader) (*http.R
 		return nil, err
 	}
 
+	req.Header.Add("API-Key", c.APIKey)
 	req.Header.Add("User-Agent", c.UserAgent)
 	req.Header.Add("Accept", mediaType)
 


### PR DESCRIPTION
This removes usage of the API as URL parameter and uses it as request header.

See <https://www.vultr.com/api/#using_the_api>:

> For any API request that requires authentication, you would need to send the 'API-Key: YOURKEY' HTTP header.