### PR TITLE
Added support for building release binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,7 @@ _testmain.go
 *.test
 *.prof
 
+# release
+dist
 # bin
 vultr

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,48 @@
+# See https://goreleaser.com/ for details
+# Build customization
+build:
+  main: vultr.go
+  binary: vultr
+  env:
+    - CGO_ENABLED=0
+  goos:
+    - darwin
+    - linux
+    - windows
+    - freebsd
+    - netbsd
+    - openbsd
+    - dragonfly
+  goarch:
+    - amd64
+    - 386
+    - arm
+    - arm64
+  ignore:
+    - goos: openbsd
+      goarch: arm
+      goarm: 6
+
+archive:
+  format: tar.gz
+  format_overrides:
+    - goos: windows
+      format: zip
+  name_template: "{{.Binary}}_{{.Version}}_{{.Os}}-{{.Arch}}"
+  replacements:
+    amd64: 64bit
+    386: 32bit
+    arm: ARM
+    arm64: ARM64
+    darwin: macOS
+    linux: Linux
+    windows: Windows
+    openbsd: OpenBSD
+    netbsd: NetBSD
+    freebsd: FreeBSD
+    dragonfly: DragonFlyBSD
+  files:
+    - README.md
+    - LICENSE
+release:
+  draft: true

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ all: prepare lint vet test build
 prepare:
 	go get -v github.com/golang/lint/golint
 	go get -v github.com/Masterminds/glide
+	go get -v github.com/goreleaser/goreleaser
 	glide install
 
 build:
@@ -34,6 +35,6 @@ test:
 check: lint vet test
 
 release:
-	goxc -os="linux darwin windows freebsd openbsd" -tasks-=validate
+	goreleaser
 
 .PHONY: all prepare build lint vet test check release


### PR DESCRIPTION
This replaces the not longer maintained [goxc](https://github.com/laher/goxc) tooling with [goreleaser](https://github.com/goreleaser/goreleaser), allowing to automatically push release binaries/archives with checksums to GitHub tags.

## Why?!

Automate a tedious task, while adding in a few additional platforms and common features such as checksums for all users.

## Possible improvements

- use [fpm](https://github.com/jordansissel/fpm) to create installable packages

## Requirements

You need to export a `GITHUB_TOKEN` environment variable, which should contain a GitHub token with the `repo` scope selected. It will be used to deploy releases to your GitHub repository. Create a token [here](https://github.com/settings/tokens/new).

```bash
$ export GITHUB_TOKEN=`YOUR_TOKEN`
```

## Pushing a release

Tag and push as usual, e.g.

```bash
$ git tag -a 1.14.0 -m "First release"
$ git push origin 1.14.0
```

Now you can run GoReleaser at the root of the repository:

```bash
$ goreleaser
```

## Building current state

To create a build for the current commit hash active, you can execute

```bash
$ goreleaser --snapshot --rm-dist
```
