### PR TITLE
Guidance requested for `backup list`, `server backup_set_schedule`, `server backup_get_schedule`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 all: prepare lint vet test build
 
 prepare:
-	go get -v github.com/golang/lint/golint
+	go get -v golang.org/x/lint/golint
 	go get -v github.com/Masterminds/glide
 	glide install
 

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -10,6 +10,11 @@ import (
 
 // RegisterCommands registers all CLI commands
 func (c *CLI) RegisterCommands() {
+	// backup
+	c.Command("backup", "see most recent backups", func(cmd *cli.Cmd) {
+		cmd.Command("list", "lists backups", backupsList)
+	})
+
 	// dns
 	c.Command("dns", "modify DNS", func(cmd *cli.Cmd) {
 		cmd.Command("domain", "show and change DNS domains", func(cmd *cli.Cmd) {
@@ -72,6 +77,10 @@ func (c *CLI) RegisterCommands() {
 
 	// servers
 	c.Command("server", "modify virtual machines", func(cmd *cli.Cmd) {
+		cmd.Command("backup", "get and set backup schedules", func(cmd *cli.Cmd) {
+			cmd.Command("get", "get a backup schedule", serversBackupGetSchedule)
+			cmd.Command("set", "set a backup schedule", serversBackupSetSchedule)
+		})
 		cmd.Command("create", "create a new virtual machine", serversCreate)
 		cmd.Command("rename", "rename a virtual machine", serversRename)
 		cmd.Command("tag", "tag a virtual machine", serversTag)

--- a/cmd/commands_backup.go
+++ b/cmd/commands_backup.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/jawher/mow.cli"
+)
+
+func backupsList(cmd *cli.Cmd) {
+	cmd.Spec = "[SUBID] [BACKUPID]"
+
+	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
+	backupid := cmd.StringArg("BACKUPID", "", "BACKUPID of a virtual machine")
+
+	cmd.Action = func() {
+		backups, err := GetClient().GetBackups(*id, *backupid)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if len(backups) == 0 {
+			fmt.Println()
+			return
+		}
+		lengths := []int{16, 16, 40, 16, 24}
+		tabsPrint(columns{"BACKUPID", "DATECREATED", "DESCRIPTION", "SIZE", "STATUS"}, lengths)
+		for _, backup := range backups {
+			tabsPrint(columns{backup.ID, backup.Created, backup.Description, backup.Size, backup.Status}, lengths)
+		}
+		tabsFlush()
+	}
+}

--- a/cmd/commands_servers.go
+++ b/cmd/commands_servers.go
@@ -72,6 +72,38 @@ func serversCreate(cmd *cli.Cmd) {
 	}
 }
 
+func serversBackupGetSchedule(cmd *cli.Cmd) {
+	cmd.Spec = "SUBID"
+	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
+
+	server, err := GetClient().BackupSetSchedule(*id)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	lengths := []int{4, 14, 32, 2, 1, 1}
+	tabsPrint(columns{"Enabled", "CronType", "NextScheduledTimeUtc", "Hour", "Dow", "Dom"}, lengths)
+	tabsPrint(columns{server.Enabled, server.CronType, server.NextScheduledTimeUtc, server.Hour, server.Dow, server.Dom}, lengths)
+	tabsFlush()
+
+}
+func serversBackupSetSchedule(cmd *cli.Cmd) {
+	cmd.Spec = "SUBID -C [-H -w -m]"
+
+	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
+	cronType := cmd.StringArg("C cronType", "", "Backup cron type. Can be one of (daily, weekly, monthly, daily_alt_even, daily_alt_odd)")
+	hour := cmd.StringArg("H hour", "", "(optional) Hour value (0-23). Applicable to crons: daily, weekly, monthly, daily_alt_even, daily_alt_odd")
+	dayOfWeek := cmd.StringArg("w dow", "", "(optional) Day-of-week value (0-6). Applicable to crons: weekly")
+	dayOfMonth := cmd.StringArg("m dom", "", "(optional) Day-of-month value (1-28). Applicable to crons: monthly")
+
+	server, err := GetClient().BackupSetSchedule(*id, *cronType, *hour, *dayOfWeek, *dayOfMonth)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Backup schedule set\n\n")
+}
+
 func serversRename(cmd *cli.Cmd) {
 	cmd.Spec = "SUBID -n"
 	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")

--- a/cmd/commands_servers.go
+++ b/cmd/commands_servers.go
@@ -76,7 +76,7 @@ func serversBackupGetSchedule(cmd *cli.Cmd) {
 	cmd.Spec = "SUBID"
 	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
 
-	server, err := GetClient().BackupSetSchedule(*id)
+	server, err := GetClient().BackupGetSchedule(*id)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -92,11 +92,16 @@ func serversBackupSetSchedule(cmd *cli.Cmd) {
 
 	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
 	cronType := cmd.StringArg("C cronType", "", "Backup cron type. Can be one of (daily, weekly, monthly, daily_alt_even, daily_alt_odd)")
-	hour := cmd.StringArg("H hour", "", "(optional) Hour value (0-23). Applicable to crons: daily, weekly, monthly, daily_alt_even, daily_alt_odd")
-	dayOfWeek := cmd.StringArg("w dow", "", "(optional) Day-of-week value (0-6). Applicable to crons: weekly")
-	dayOfMonth := cmd.StringArg("m dom", "", "(optional) Day-of-month value (1-28). Applicable to crons: monthly")
-
-	server, err := GetClient().BackupSetSchedule(*id, *cronType, *hour, *dayOfWeek, *dayOfMonth)
+	hour := cmd.IntOpt("H hour", 0, "(optional) Hour value (0-23). Applicable to crons: daily, weekly, monthly, daily_alt_even, daily_alt_odd")
+	dayOfWeek := cmd.IntOpt("w dow", 0, "(optional) Day-of-week value (0-6). Applicable to crons: weekly")
+	dayOfMonth := cmd.IntOpt("m dom", 0, "(optional) Day-of-month value (1-28). Applicable to crons: monthly")
+	bs := vultr.BackupSchedule{
+		CronType: *cronType,
+		Hour:     *hour,
+		Dow:      *dayOfWeek,
+		Dom:      *dayOfMonth,
+	}
+	err := GetClient().BackupSetSchedule(*id, bs)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/lib/backup.go
+++ b/lib/backup.go
@@ -1,0 +1,43 @@
+package lib
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// BackupSchedule represents a scheduled backup on a server
+// see: server/backup_set_schedule, server/backup_get_schedule
+type BackupSchedule struct {
+	Enabled              bool   `json:"enabled"`
+	CronType             string `json:"cron_type"`
+	NextScheduledTimeUtc string `json:"next_scheduled_time_utc"`
+	Hour                 int    `json:"hour"`
+	Dow                  int    `json:"dow"`
+	Dom                  int    `json:"dom"`
+}
+
+// Backup of a virtual machine
+type Backup struct {
+	ID          string `json:"BACKUPID"`
+	Created     string `json:"date_created"`
+	Description string `json:"description"`
+	Size        string `json:"size"`
+	Status      string `json:"status"`
+}
+
+type backups []Backup
+
+// GetBackups retrieves a list of all backups on Vultr account
+func (c *Client) GetBackups() (backupList []BackupSchedule, err error) {
+	var backupSchedulesMap map[string]BackupSchedule
+	if err := c.get(`backup/list`, &backupSchedulesMap); err != nil {
+		return nil, err
+	}
+
+	for _, backup := range backupSchedulesMap {
+		backupList = append(backupList, backup)
+	}
+	sort.Sort(backups(backupList))
+	return backupList, nil
+}

--- a/lib/backup.go
+++ b/lib/backup.go
@@ -28,16 +28,27 @@ type Backup struct {
 
 type backups []Backup
 
+func (s backups) Len() int      { return len(s) }
+func (s backups) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s backups) Less(i, j int) bool {
+	return strings.ToLower(s[i].Name) < strings.ToLower(s[j].Name)
+}
+
 // GetBackups retrieves a list of all backups on Vultr account
-func (c *Client) GetBackups() (backupList []BackupSchedule, err error) {
-	var backupSchedulesMap map[string]BackupSchedule
-	if err := c.get(`backup/list`, &backupSchedulesMap); err != nil {
+func (c *Client) GetBackups(id string, backupid string) (backupList []BackupSchedule, err error) {
+	var backupMap map[string]Backup
+	values := url.Values{
+		"SUBID":    {id},
+		"BACKUPID": {backupid},
+	}
+
+	if err := c.post(`backup/list`, values, &backupMap); err != nil {
 		return nil, err
 	}
 
-	for _, backup := range backupSchedulesMap {
-		backupList = append(backupList, backup)
+	for _, backup := range backupMap {
+		backups = append(backups, backup)
 	}
-	sort.Sort(backups(backupList))
-	return backupList, nil
+	sort.Sort(backups(backups))
+	return backups, nil
 }

--- a/lib/backup.go
+++ b/lib/backup.go
@@ -6,17 +6,6 @@ import (
 	"strings"
 )
 
-// BackupSchedule represents a scheduled backup on a server
-// see: server/backup_set_schedule, server/backup_get_schedule
-type BackupSchedule struct {
-	Enabled              bool   `json:"enabled"`
-	CronType             string `json:"cron_type"`
-	NextScheduledTimeUtc string `json:"next_scheduled_time_utc"`
-	Hour                 int    `json:"hour"`
-	Dow                  int    `json:"dow"`
-	Dom                  int    `json:"dom"`
-}
-
 // Backup of a virtual machine
 type Backup struct {
 	ID          string `json:"BACKUPID"`
@@ -35,7 +24,7 @@ func (s backups) Less(i, j int) bool {
 }
 
 // GetBackups retrieves a list of all backups on Vultr account
-func (c *Client) GetBackups(id string, backupid string) (backupList []BackupSchedule, err error) {
+func (c *Client) GetBackups(id string, backupid string) (backups []Backup, err error) {
 	var backupMap map[string]Backup
 	values := url.Values{
 		"SUBID":    {id},

--- a/lib/backup_test.go
+++ b/lib/backup_test.go
@@ -26,23 +26,23 @@ func Test_Backups_GetBackups_OK(t *testing.T) {
 }`)
 	defer server.Close()
 
-	snapshots, err := client.GetBackups()
+	snapshots, err := client.GetBackups("123456789", "1")
 	if err != nil {
 		t.Error(err)
 	}
 	if assert.NotNil(t, snapshots) {
 		assert.Equal(t, 2, len(snapshots))
 
-		assert.Equal(t, "543d340f6dbce", snapshots[0].ID)
-		assert.Equal(t, "2014-10-13 16:11:46", snapshots[0].Created)
-		assert.Equal(t, "a", snapshots[0].Description)
-		assert.Equal(t, "10000000", snapshots[0].Size)
-		assert.Equal(t, "complete", snapshots[0].Status)
-
 		assert.Equal(t, "543d34149403a", snapshots[0].ID)
 		assert.Equal(t, "2014-10-14 12:40:40", snapshots[0].Created)
 		assert.Equal(t, "Automatic server backup", snapshots[0].Description)
 		assert.Equal(t, "42949672960", snapshots[0].Size)
 		assert.Equal(t, "complete", snapshots[0].Status)
+
+		assert.Equal(t, "543d340f6dbce", snapshots[1].ID)
+		assert.Equal(t, "2014-10-13 16:11:46", snapshots[1].Created)
+		assert.Equal(t, "a", snapshots[1].Description)
+		assert.Equal(t, "10000000", snapshots[1].Size)
+		assert.Equal(t, "complete", snapshots[1].Status)
 	}
 }

--- a/lib/backup_test.go
+++ b/lib/backup_test.go
@@ -1,0 +1,48 @@
+package lib
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Backups_GetBackups_OK(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusOK, `{
+    "543d340f6dbce": {
+        "BACKUPID": "543d340f6dbce",
+        "date_created": "2014-10-13 16:11:46",
+        "description": "a",
+        "size": "10000000",
+        "status": "complete"
+    },
+    "543d34149403a": {
+        "BACKUPID": "543d34149403a",
+        "date_created": "2014-10-14 12:40:40",
+        "description": "Automatic server backup",
+        "size": "42949672960",
+        "status": "complete"
+    }
+}`)
+	defer server.Close()
+
+	snapshots, err := client.GetBackups()
+	if err != nil {
+		t.Error(err)
+	}
+	if assert.NotNil(t, snapshots) {
+		assert.Equal(t, 2, len(snapshots))
+
+		assert.Equal(t, "543d340f6dbce", snapshots[0].ID)
+		assert.Equal(t, "2014-10-13 16:11:46", snapshots[0].Created)
+		assert.Equal(t, "a", snapshots[0].Description)
+		assert.Equal(t, "10000000", snapshots[0].Size)
+		assert.Equal(t, "complete", snapshots[0].Status)
+
+		assert.Equal(t, "543d34149403a", snapshots[0].ID)
+		assert.Equal(t, "2014-10-14 12:40:40", snapshots[0].Created)
+		assert.Equal(t, "Automatic server backup", snapshots[0].Description)
+		assert.Equal(t, "42949672960", snapshots[0].Size)
+		assert.Equal(t, "complete", snapshots[0].Status)
+	}
+}

--- a/lib/backup_test.go
+++ b/lib/backup_test.go
@@ -26,23 +26,34 @@ func Test_Backups_GetBackups_OK(t *testing.T) {
 }`)
 	defer server.Close()
 
-	snapshots, err := client.GetBackups("123456789", "1")
+	backups, err := client.GetBackups("123456789", "asdf")
 	if err != nil {
 		t.Error(err)
 	}
-	if assert.NotNil(t, snapshots) {
-		assert.Equal(t, 2, len(snapshots))
+	if assert.NotNil(t, backups) {
+		assert.Equal(t, 2, len(backups))
 
-		assert.Equal(t, "543d34149403a", snapshots[0].ID)
-		assert.Equal(t, "2014-10-14 12:40:40", snapshots[0].Created)
-		assert.Equal(t, "Automatic server backup", snapshots[0].Description)
-		assert.Equal(t, "42949672960", snapshots[0].Size)
-		assert.Equal(t, "complete", snapshots[0].Status)
+		assert.Equal(t, "543d34149403a", backups[0].ID)
+		assert.Equal(t, "2014-10-14 12:40:40", backups[0].Created)
+		assert.Equal(t, "Automatic server backup", backups[0].Description)
+		assert.Equal(t, "42949672960", backups[0].Size)
+		assert.Equal(t, "complete", backups[0].Status)
 
-		assert.Equal(t, "543d340f6dbce", snapshots[1].ID)
-		assert.Equal(t, "2014-10-13 16:11:46", snapshots[1].Created)
-		assert.Equal(t, "a", snapshots[1].Description)
-		assert.Equal(t, "10000000", snapshots[1].Size)
-		assert.Equal(t, "complete", snapshots[1].Status)
+		assert.Equal(t, "543d340f6dbce", backups[1].ID)
+		assert.Equal(t, "2014-10-13 16:11:46", backups[1].Created)
+		assert.Equal(t, "a", backups[1].Description)
+		assert.Equal(t, "10000000", backups[1].Size)
+		assert.Equal(t, "complete", backups[1].Status)
+	}
+}
+
+func Test_Servers_Backups_GetBackups_Error(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
+	defer server.Close()
+
+	backups, err := client.GetBackups("123456789", "asdf")
+	assert.Nil(t, backups)
+	if assert.NotNil(t, err) {
+		assert.Equal(t, `{error}`, err.Error())
 	}
 }

--- a/lib/servers.go
+++ b/lib/servers.go
@@ -663,13 +663,13 @@ type BackupScheduleResponse struct {
 }
 
 // BackupGetSchedule returns a virtual machines backup schedule
-func (c *Client) BackupGetSchedule(id string) (BackupScheduleResponse, error) {
+func (c *Client) BackupGetSchedule(id string) (*BackupScheduleResponse, error) {
+	var bsr = &BackupScheduleResponse{}
 	values := url.Values{
 		"SUBID": {id},
 	}
-	var bsr BackupScheduleResponse
 	if err := c.post(`server/backup_get_schedule`, values, &bsr); err != nil {
-		return bsr, err
+		return nil, err
 	}
 	return bsr, nil
 }

--- a/lib/servers.go
+++ b/lib/servers.go
@@ -649,7 +649,6 @@ func (c *Client) EnablePrivateNetworkForServer(id, networkID string) error {
 // BackupSchedule represents a scheduled backup on a server
 // see: server/backup_set_schedule, server/backup_get_schedule
 type BackupSchedule struct {
-	Enabled              bool   `json:"enabled"`
 	CronType             string `json:"cron_type"`
 	NextScheduledTimeUtc string `json:"next_scheduled_time_utc"`
 	Hour                 int    `json:"hour"`
@@ -657,22 +656,31 @@ type BackupSchedule struct {
 	Dom                  int    `json:"dom"`
 }
 
+type BackupScheduleResponse struct {
+	Enabled bool `json:"enabled"`
+	BackupSchedule
+}
+
 // BackupGetSchedule
-func (c *Client) BackupGetSchedule(id string) (BackupSchedule, error) {
+func (c *Client) BackupGetSchedule(id string) (BackupScheduleResponse, error) {
 	values := url.Values{
 		"SUBID": {id},
 	}
-	return c.post(`server/backup_get_schedule`, values, nil)
+	var bsr BackupScheduleResponse
+	if err := c.post(`server/backup_get_schedule`, values, &bsr); err != nil {
+		return bsr, err
+	}
+	return bsr, nil
 }
 
 // BackupSetSchedule
-func (c *Client) BackupSetSchedule(id string, cronType string, hour int, dayOfWeek int, dayOfMonth int) error {
+func (c *Client) BackupSetSchedule(id string, bs BackupSchedule) error {
 	values := url.Values{
 		"SUBID":     {id},
-		"cron_type": {cronType},
-		"hour":      {hour},
-		"dow":       {dayOfWeek},
-		"dom":       {dayOfMonth},
+		"cron_type": {bs.CronType},
+		"hour":      {string(bs.Hour)},
+		"dow":       {string(bs.Dow)},
+		"dom":       {string(bs.Dom)},
 	}
 	return c.post(`server/backup_set_schedule`, values, nil)
 }

--- a/lib/servers.go
+++ b/lib/servers.go
@@ -656,12 +656,13 @@ type BackupSchedule struct {
 	Dom                  int    `json:"dom"`
 }
 
+// BackupScheduleResponse details about a virtual machines backup schedule
 type BackupScheduleResponse struct {
 	Enabled bool `json:"enabled"`
 	BackupSchedule
 }
 
-// BackupGetSchedule
+// BackupGetSchedule returns a virtual machines backup schedule
 func (c *Client) BackupGetSchedule(id string) (BackupScheduleResponse, error) {
 	values := url.Values{
 		"SUBID": {id},
@@ -673,7 +674,7 @@ func (c *Client) BackupGetSchedule(id string) (BackupScheduleResponse, error) {
 	return bsr, nil
 }
 
-// BackupSetSchedule
+// BackupSetSchedule sets the backup schedule given a BackupSchedule struct
 func (c *Client) BackupSetSchedule(id string, bs BackupSchedule) error {
 	values := url.Values{
 		"SUBID":     {id},

--- a/lib/servers.go
+++ b/lib/servers.go
@@ -645,3 +645,34 @@ func (c *Client) EnablePrivateNetworkForServer(id, networkID string) error {
 
 	return c.post(`server/private_network_enable`, values, nil)
 }
+
+// BackupSchedule represents a scheduled backup on a server
+// see: server/backup_set_schedule, server/backup_get_schedule
+type BackupSchedule struct {
+	Enabled              bool   `json:"enabled"`
+	CronType             string `json:"cron_type"`
+	NextScheduledTimeUtc string `json:"next_scheduled_time_utc"`
+	Hour                 int    `json:"hour"`
+	Dow                  int    `json:"dow"`
+	Dom                  int    `json:"dom"`
+}
+
+// BackupGetSchedule
+func (c *Client) BackupGetSchedule(id string) (BackupSchedule, error) {
+	values := url.Values{
+		"SUBID": {id},
+	}
+	return c.post(`server/backup_get_schedule`, values, nil)
+}
+
+// BackupSetSchedule
+func (c *Client) BackupSetSchedule(id string, cronType string, hour int, dayOfWeek int, dayOfMonth int) error {
+	values := url.Values{
+		"SUBID":     {id},
+		"cron_type": {cronType},
+		"hour":      {hour},
+		"dow":       {dayOfWeek},
+		"dom":       {dayOfMonth},
+	}
+	return c.post(`server/backup_set_schedule`, values, nil)
+}

--- a/lib/servers_test.go
+++ b/lib/servers_test.go
@@ -699,3 +699,31 @@ func Test_Servers_EnablePrivateNetworkForServer_OK(t *testing.T) {
 
 	assert.Nil(t, client.EnablePrivateNetworkForServer("123456789", "foo"))
 }
+
+func Test_Servers_BackupGetSchedule_OK(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusOK, `{
+    "enabled": true,
+    "cron_type": "weekly",
+    "next_scheduled_time_utc": "2016-05-07 08:00:00",
+    "hour": 8,
+    "dow": 6,
+    "dom": 0
+}`)
+	defer server.Close()
+
+	backupSchedule, err := client.BackupGetSchedule("123456789")
+	if err {
+		t.Error(err)
+	}
+	if assert.NotNil(t, backupSchedule) {
+		assert.Equal(t, 1, len(backupSchedule))
+		assert.Equal(t, true, backupSchedule[0].Enabled)
+		assert.Equal(t, "weekly", backupSchedule[0].CronType)
+		assert.Equal(t, "2016-05-07 08:00:00", backupSchedule[0].NextScheduledTimeUtc)
+		assert.Equal(t, "8", backupSchedule[0].Hour)
+		assert.Equal(t, "6", backupSchedule[0].Dow)
+		assert.Equal(t, "0", backupSchedule[0].Dom)
+
+	}
+
+}

--- a/lib/servers_test.go
+++ b/lib/servers_test.go
@@ -727,3 +727,10 @@ func Test_Servers_BackupGetSchedule_OK(t *testing.T) {
 	}
 
 }
+
+func Test_Servers_BackupSetSchedule_OK(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusOK, `{no-response?!}`)
+	defer server.Close()
+
+	assert.Nil(t, client.BackupSetSchedule("123456789"))
+}

--- a/lib/servers_test.go
+++ b/lib/servers_test.go
@@ -712,17 +712,16 @@ func Test_Servers_BackupGetSchedule_OK(t *testing.T) {
 	defer server.Close()
 
 	backupSchedule, err := client.BackupGetSchedule("123456789")
-	if err {
+	if err != nil {
 		t.Error(err)
 	}
 	if assert.NotNil(t, backupSchedule) {
-		assert.Equal(t, 1, len(backupSchedule))
-		assert.Equal(t, true, backupSchedule[0].Enabled)
-		assert.Equal(t, "weekly", backupSchedule[0].CronType)
-		assert.Equal(t, "2016-05-07 08:00:00", backupSchedule[0].NextScheduledTimeUtc)
-		assert.Equal(t, "8", backupSchedule[0].Hour)
-		assert.Equal(t, "6", backupSchedule[0].Dow)
-		assert.Equal(t, "0", backupSchedule[0].Dom)
+		assert.Equal(t, true, backupSchedule.Enabled)
+		assert.Equal(t, "weekly", backupSchedule.CronType)
+		assert.Equal(t, "2016-05-07 08:00:00", backupSchedule.NextScheduledTimeUtc)
+		assert.Equal(t, 8, backupSchedule.Hour)
+		assert.Equal(t, 6, backupSchedule.Dow)
+		assert.Equal(t, 0, backupSchedule.Dom)
 
 	}
 
@@ -732,5 +731,5 @@ func Test_Servers_BackupSetSchedule_OK(t *testing.T) {
 	server, client := getTestServerAndClient(http.StatusOK, `{no-response?!}`)
 	defer server.Close()
 
-	assert.Nil(t, client.BackupSetSchedule("123456789"))
+	assert.Nil(t, client.BackupSetSchedule("123456789", BackupSchedule{}))
 }

--- a/lib/servers_test.go
+++ b/lib/servers_test.go
@@ -733,3 +733,24 @@ func Test_Servers_BackupSetSchedule_OK(t *testing.T) {
 
 	assert.Nil(t, client.BackupSetSchedule("123456789", BackupSchedule{}))
 }
+
+func Test_Servers_BackupGetSchedule_Error(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
+	defer server.Close()
+
+	backupSchedule, err := client.BackupGetSchedule("123456789")
+	assert.Nil(t, backupSchedule)
+	if assert.NotNil(t, err) {
+		assert.Equal(t, `{error}`, err.Error())
+	}
+}
+
+func Test_Servers_BackupSetSchedule_Error(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
+	defer server.Close()
+
+	err := client.BackupSetSchedule("123456789", BackupSchedule{})
+	if assert.NotNil(t, err) {
+		assert.Equal(t, `{error}`, err.Error())
+	}
+}


### PR DESCRIPTION
I noticed that these endpoints might be a bit related:

- `/v1/backup/list`(https://www.vultr.com/api/#backup_backup_list)
- `/v1/server/backup_set_schedule` (https://www.vultr.com/api/#server_backup_get_schedule)
- `/v1/server/backup_get_schedule` (https://www.vultr.com/api/#server_backup_set_schedule)

What I'm wondering is should `set/get_schedule` be imported from `backup.go`, or should it be defined and included as part of `server.go`?

More specifically wondering where `BackupSchedule struct` should live.

**edit:**

example cmds:
- `vultr backup list`
- `vultr server backup set`
- `vultr server backup get`

although now that i think about it a bit, it makes more sense to keep the API aligned, so the 

`BackupSchedule struct` should go in `server.go`. Thoughts?

also, thanks for the great library!

**edit2**

I've also updated the Makefile I was having issues with the location of golint, and added the rest of the command parts.


