### PR TITLE
add support for virtual machine plan upgrades

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -128,7 +128,7 @@ func (c *CLI) RegisterCommands() {
 		cmd.Command("unset-firewall-group", "remove virtual machine from firewall group", serversUnsetFirewallGroup)
 		// upgrade plans
 		cmd.Command("upgrade-plan", "upgrade plan of a virtual machine", func(cmd *cli.Cmd) {
-			cmd.Command("change", "change (upgrade) plan of virtual machine", serversChangePlan)
+			cmd.Command("change", "upgrade plan of virtual machine (Note: Downgrading is currently not supported. Shrinking the hard disk is not possible without risking data loss.)", serversChangePlan)
 			cmd.Command("list", "show a list of VPSPLANIDs to which a virtual machine can be upgraded to", serversListUpgradePlans)
 		})
 	})

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -126,6 +126,11 @@ func (c *CLI) RegisterCommands() {
 		// firewall groups
 		cmd.Command("set-firewall-group", "set firewall group of a virtual machine", serversSetFirewallGroup)
 		cmd.Command("unset-firewall-group", "remove virtual machine from firewall group", serversUnsetFirewallGroup)
+		// upgrade plans
+		cmd.Command("upgrade-plan", "upgrade plan of a virtual machine", func(cmd *cli.Cmd) {
+			cmd.Command("change", "change (upgrade) plan of virtual machine", serversChangePlan)
+			cmd.Command("list", "show a list of VPSPLANIDs to which a virtual machine can be upgraded to", serversListUpgradePlans)
+		})
 	})
 	c.Command("servers", "list all active or pending virtual machines on current account", serversList)
 

--- a/cmd/commands_servers.go
+++ b/cmd/commands_servers.go
@@ -663,3 +663,37 @@ func serversAppInfo(cmd *cli.Cmd) {
 		fmt.Printf("%s", app.Info)
 	}
 }
+
+func serversChangePlan(cmd *cli.Cmd) {
+	cmd.Spec = "SUBID VPSPLANID"
+	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
+	planID := cmd.IntArg("VPSPLANID", 0, "Plan (VPSPLANID)")
+
+	cmd.Action = func() {
+		if err := GetClient().ChangePlanOfServer(*id, *planID); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Virtual machine plan changed to: %v\n", *planID)
+	}
+}
+func serversListUpgradePlans(cmd *cli.Cmd) {
+	id := cmd.StringArg("SUBID", "", "SUBID of virtual machine (see <servers>)")
+	cmd.Action = func() {
+		plans, err := GetClient().ListUpgradePlansForServer(*id)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if len(plans) == 0 {
+			fmt.Printf("0 available plans for virtual machine with SUBID %v to upgrade to.", *id)
+			return
+		}
+
+		lengths := []int{12}
+		tabsPrint(columns{"VPSPLANID"}, lengths)
+		for _, p := range plans {
+			tabsPrint(columns{p}, lengths)
+		}
+		tabsFlush()
+	}
+}

--- a/lib/servers.go
+++ b/lib/servers.go
@@ -698,3 +698,25 @@ func (c *Client) BackupSetSchedule(id string, bs BackupSchedule) error {
 	}
 	return c.post(`server/backup_set_schedule`, values, nil)
 }
+
+// ChangePlanOfServer changes the virtual machine to a different plan
+func (c *Client) ChangePlanOfServer(id string, planID int) error {
+	values := url.Values{
+		"SUBID":     {id},
+		"VPSPLANID": {fmt.Sprintf("%v", planID)},
+	}
+
+	if err := c.post(`server/upgrade_plan`, values, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ListUpgradePlansForServer retrieves a list of the VPSPLANIDs for which a virtual machine can be upgraded.
+// An empty response means that there are currently no upgrades available
+func (c *Client) ListUpgradePlansForServer(id string) (planIDs []int, err error) {
+	if err := c.get(`server/upgrade_plan_list?SUBID=`+id, &planIDs); err != nil {
+		return nil, err
+	}
+	return
+}

--- a/lib/servers_test.go
+++ b/lib/servers_test.go
@@ -754,3 +754,63 @@ func Test_Servers_BackupSetSchedule_Error(t *testing.T) {
 		assert.Equal(t, `{error}`, err.Error())
 	}
 }
+
+func Test_Servers_ChangePlanOfServer_Error(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
+	defer server.Close()
+
+	err := client.ChangePlanOfServer("123456789", 205)
+	if assert.NotNil(t, err) {
+		assert.Equal(t, `{error}`, err.Error())
+	}
+}
+
+func Test_Servers_ChangePlanOfServer_OK(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusOK, `{no-response?!}`)
+	defer server.Close()
+
+	assert.Nil(t, client.ChangePlanOfServer("123456789", 205))
+}
+
+func Test_Servers_ListUpgradePlansForServer_Error(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusNotAcceptable, `{error}`)
+	defer server.Close()
+
+	p, err := client.ListUpgradePlansForServer("123456789")
+	assert.Nil(t, p)
+	if assert.NotNil(t, err) {
+		assert.Equal(t, `{error}`, err.Error())
+	}
+}
+
+func Test_Servers_ListUpgradePlansForServer_NoPlan(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusOK, `[]`)
+	defer server.Close()
+
+	p, err := client.ListUpgradePlansForServer("123456789")
+	if err != nil {
+		t.Error(err)
+	}
+	assert.Nil(t, p)
+}
+
+func Test_Servers_ListUpgradePlansForServer_OK(t *testing.T) {
+	server, client := getTestServerAndClient(http.StatusOK, `[
+		29,
+		41,
+		61
+	]`)
+	defer server.Close()
+
+	p, err := client.ListUpgradePlansForServer("123456789")
+	if err != nil {
+		t.Error(err)
+	}
+	if assert.NotNil(t, p) {
+		assert.Equal(t, 3, len(p))
+
+		assert.Equal(t, 29, p[0])
+		assert.Equal(t, 41, p[1])
+		assert.Equal(t, 61, p[2])
+	}
+}


### PR DESCRIPTION
Add support for upgrading plans on a virtual machine.

Usage:
`vultr server upgrade-plan list <SUBID>`
`vultr server upgrade-plan change <SUBID> <VPSPLANID>`

https://www.vultr.com/api/#server_upgrade_plan_list
https://www.vultr.com/api/#server_upgrade_plan