### PR TITLE
Add optional notes to firewall rules

### DIFF
--- a/cmd/commands_firewall.go
+++ b/cmd/commands_firewall.go
@@ -83,7 +83,7 @@ func firewallGroupList(cmd *cli.Cmd) {
 }
 
 func firewallRuleCreate(cmd *cli.Cmd) {
-	cmd.Spec = "-g -n ((--tcp --port) | (--udp --port) | --icmp | --gre)"
+	cmd.Spec = "-g -n ((--tcp --port) | (--udp --port) | --icmp | --gre) [--notes]"
 	gid := cmd.StringOpt("g group-id", "", "Firewall group ID (see <firewall group list>)")
 	cidr := cmd.StringOpt("n network", "0.0.0.0/0", "IPv4/IPv6 network in CIDR notation")
 	tcp := cmd.BoolOpt("tcp", false, "TCP protocol")
@@ -91,6 +91,7 @@ func firewallRuleCreate(cmd *cli.Cmd) {
 	icmp := cmd.BoolOpt("icmp", false, "ICMP protocol")
 	gre := cmd.BoolOpt("gre", false, "GRE protocol")
 	port := cmd.StringOpt("port", "", "Port number or port range (TCP/UDP only)")
+	notes := cmd.StringOpt("notes", "", "Optional note")
 
 	cmd.Action = func() {
 		var protocol string
@@ -110,7 +111,7 @@ func firewallRuleCreate(cmd *cli.Cmd) {
 			log.Fatalf("Invalid network CIDR: %s", *cidr)
 		}
 
-		ruleNum, err := GetClient().CreateFirewallRule(*gid, protocol, *port, network)
+		ruleNum, err := GetClient().CreateFirewallRule(*gid, protocol, *port, network, *notes)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/commands_firewall.go
+++ b/cmd/commands_firewall.go
@@ -117,9 +117,9 @@ func firewallRuleCreate(cmd *cli.Cmd) {
 		}
 
 		fmt.Printf("Firewall rule created\n\n")
-		lengths := []int{10, 10, 10, 12, 20}
-		tabsPrint(columns{"GROUP_ID", "RULE_NUM", "PROTOCOL", "PORT", "NETWORK"}, lengths)
-		tabsPrint(columns{*gid, ruleNum, protocol, *port, network}, lengths)
+		lengths := []int{10, 10, 10, 12, 20, 30}
+		tabsPrint(columns{"GROUP_ID", "RULE_NUM", "PROTOCOL", "PORT", "NETWORK", "NOTES"}, lengths)
+		tabsPrint(columns{*gid, ruleNum, protocol, *port, network, *notes}, lengths)
 		tabsFlush()
 	}
 }
@@ -155,8 +155,8 @@ func firewallRuleList(cmd *cli.Cmd) {
 			return
 		}
 
-		lengths := []int{10, 10, 8, 12, 20}
-		tabsPrint(columns{"RULE_NUM", "ACTION", "PROTOCOL", "PORT", "NETWORK"}, lengths)
+		lengths := []int{10, 10, 8, 12, 20, 30}
+		tabsPrint(columns{"RULE_NUM", "ACTION", "PROTOCOL", "PORT", "NETWORK", "NOTES"}, lengths)
 		for _, r := range rules {
 			tabsPrint(columns{
 				r.RuleNumber,
@@ -164,6 +164,7 @@ func firewallRuleList(cmd *cli.Cmd) {
 				r.Protocol,
 				r.Port,
 				r.Network.String(),
+				r.Notes,
 			}, lengths)
 		}
 		tabsFlush()

--- a/lib/firewall.go
+++ b/lib/firewall.go
@@ -28,6 +28,7 @@ type FirewallRule struct {
 	Protocol   string `json:"protocol"`
 	Port       string `json:"port"`
 	Network    *net.IPNet
+	Notes      string `json:"notes"`
 }
 
 type firewallGroups []FirewallGroup
@@ -83,6 +84,7 @@ func (r *FirewallRule) UnmarshalJSON(data []byte) (err error) {
 	r.Action = fmt.Sprintf("%v", fields["action"])
 	r.Protocol = fmt.Sprintf("%v", fields["protocol"])
 	r.Port = fmt.Sprintf("%v", fields["port"])
+	r.Notes = fmt.Sprintf("%v", fields["notes"])
 	subnet := fmt.Sprintf("%v", fields["subnet"])
 	if subnet == "<nil>" {
 		subnet = ""
@@ -198,7 +200,7 @@ func (c *Client) GetFirewallRules(groupID string) ([]FirewallRule, error) {
 // protocol must be one of: "icmp", "tcp", "udp", "gre"
 // port can be a port number or colon separated port range (TCP/UDP only)
 func (c *Client) CreateFirewallRule(groupID, protocol, port string,
-	network *net.IPNet) (int, error) {
+	network *net.IPNet, notes string) (int, error) {
 	ip := network.IP.String()
 	maskBits, _ := network.Mask.Size()
 	if ip == "<nil>" {
@@ -228,6 +230,10 @@ func (c *Client) CreateFirewallRule(groupID, protocol, port string,
 
 	if len(port) > 0 {
 		values.Add("port", port)
+	}
+
+	if len(notes) > 0 {
+		values.Add("notes", notes)
 	}
 
 	var result FirewallRule

--- a/lib/firewall_test.go
+++ b/lib/firewall_test.go
@@ -178,7 +178,7 @@ func Test_Firewall_CreateRule_Ok(t *testing.T) {
 	defer server.Close()
 
 	_, netw, _ := net.ParseCIDR("10.234.22.0/24")
-	num, err := client.CreateFirewallRule("1a", "tcp", "80", netw)
+	num, err := client.CreateFirewallRule("1a", "tcp", "80", netw, "some-example-note")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Heya 👋 

Thank you for creating and sharing this repository!
Recently, Vultr added the option to leave a small note on a firewall rule. Extra convenient when you are trying to remember who a certain entry belongs to.

This PR should allow users to use this new notes functionality by adding an optional `--notes` flag to the firewall rule creation command. Let me know what you think.
The functional result:
<img width="840" alt="Screenshot 2019-03-19 at 21 53 01" src="https://user-images.githubusercontent.com/3368018/54641521-ae368500-4a92-11e9-97e3-010e936df0a3.png">
<img width="840" alt="Screenshot 2019-03-19 at 21 55 45" src="https://user-images.githubusercontent.com/3368018/54641522-ae368500-4a92-11e9-9a94-b447b72cc210.png">

### Notes / questions:
I'm still a bit new to the language, so if you have any comments or suggestions: let me know! I've written down some thoughts below. Maybe you can help me out with these?

 - Is there a way to handle the API change of `CreateFirewallRule` more gracefully? I don't think that optional arguments is a thing in golang 🤔 
 - What about validation rules? The API docs state that there is a limit of 255 characters. Should we validate the data before we send it? 
 - Any way I can test this better? 